### PR TITLE
Support for YYYY-MM format

### DIFF
--- a/lib/parseformat.js
+++ b/lib/parseformat.js
@@ -37,6 +37,8 @@ var regexHoursMinutesSecondsCentiSeconds = /\d{1,2}:\d{2}:\d{2}\.\d{2}/
 var regexHoursMinutesSecondsDeciSeconds = /\d{1,2}:\d{2}:\d{2}\.\d{1}/
 var regexHoursMinutes = /\d{1,2}:\d{2}/
 var regexYearLong = /\d{4}/
+var regexMonthLeadingZero = /(0[1-9]|[10-12])/
+var regexMonth = /([1-12])/
 var regexDayLeadingZero = /0\d/
 var regexDay = /\d{1,2}/
 var regexYearShort = /\d{2}/
@@ -173,6 +175,9 @@ function parseFormat (dateString, options) {
     format = format.replace(regexHoursDotWithLeadingZeroOrDoubleDigitMinutes, 'H.mm')
     format = format.replace(regexHoursDotMinutes, 'h.mm')
   }
+
+  format = format.replace(regexMonthLeadingZero, 'MM')
+  format = format.replace(regexMonth, 'M')
 
   // now, the next number, if existing, must be a day
   format = format.replace(regexDayLeadingZero, 'DD')


### PR DESCRIPTION
On YYYY-MM format parsing preference was for date. Now checks for months first, if not then will revert to Date.